### PR TITLE
reference latest scalafx version available for scala 2.10, 2.11 and 2.12

### DIFF
--- a/_docs/quickstart.md
+++ b/_docs/quickstart.md
@@ -16,7 +16,7 @@ For JavaFX 8 (distributed with Java 8) you will need to add dependency on ScalaF
 For instance, if you are using Java8 and SBT as your build system, add the following line to `build.sbt`
 
 {% highlight scala %}
-libraryDependencies += "org.scalafx" %% "scalafx" % "8.0.92-R10"
+libraryDependencies += "org.scalafx" %% "scalafx" % "8.0.144-R12"
 {% endhighlight %}
 
 You can download ScalaFX releases from [Maven repository at Sonatype](http://search.maven.org/#search&#124;ga&#124;1&#124;scalafx).


### PR DESCRIPTION
currently referenced version (8.0.92-R10) only works for scala 2.11 (for other scala versions artifact is not present)

scalafx version 8.0.144-R12 library artifact is available for all current scala versions

also version update as stated here: https://github.com/scalafx/scalafx-hello-world/commit/d778893b22c37d336acd504fe322cdbcfed7c6cb