### PR TITLE
Remove link to G+ Community

### DIFF
--- a/_includes/home_links.html
+++ b/_includes/home_links.html
@@ -6,11 +6,6 @@
         </li>
 
         <li>
-            <a href="https://plus.google.com/u/0/communities/114426675027810611240" rel="nofollow">ScalaFX G+
-                Community</a>
-        </li>
-
-        <li>
             <a href="http://steveonjava.com/" rel="nofollow">Steve on Java</a>
         </li>
 


### PR DESCRIPTION
Google Plus is no more.